### PR TITLE
[WB-25] Create tables as part of startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,13 @@ services:
       - rediscluster
   postgres:
     image: 'postgres:9.6.3-alpine'
+    # Additional initialization, see 'extending' https://hub.docker.com/_/postgres/
+    volumes:
+      - ./docker-helpers/postgres:/docker-entrypoint-initdb.d
+    environment:
+      POSTGRES_USER: 'postgres'
+      POSTGRES_PASSWORD: 'postgres'
+      POSTGRES_DATABASES: 'windbreaker_core,windbreaker_hooks'
     ports:
       - 5432
   rabbitmq:

--- a/docker-helpers/postgres/createDatabases.sh
+++ b/docker-helpers/postgres/createDatabases.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+function createDatabase () {
+  local dbName=$1
+  local user=$2
+  local pass=$3
+
+  echo "Creating database '$dbName'"
+  psql -v ON_ERROR_STOP=1 --username "$user" --password "$pass"<<-EOL
+    CREATE USER $user;
+    CREATE DATABASE $dbName;
+    GRANT ALL PRIVILEGES ON DATABASE $dbName TO $user;
+EOL
+  echo "Done creating '$dbName'"
+}
+
+IFS=',' read -ra dbNames <<< "$POSTGRES_DATABASES"
+for dbName in "${dbNames[@]}"; do
+  # trim leading/trailing whitespace
+  dbName=$(echo "$dbName" | xargs)
+  createDatabase $dbName $POSTGRES_USER $POSTGRES_PASSWORD
+done


### PR DESCRIPTION
This allows us to avoid using pre-migration knex connect -> create database -> destroy knex connection -> continue with migration flow. The migrations will run with the expectation that db creation has already been handled (by this change). This is needed because the postgres docker image doesn't support creation of multiple DBs by default.